### PR TITLE
Add RetroDragon's Dark Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ This is an incomplete list of themes created by Aseprite users (pull requests ar
 
 <a href="https://github.com/dracula/aseprite">Aseprite Dracula Theme<br>
 <img src="https://github.com/dracula/aseprite/blob/master/screenshot.png" width="400px" /><a>
+
+----
+
+<a href="https://theretrodragon.itch.io/aseprite-darkblue-theme">RetroDragon's Dark Theme<br>
+<img src="https://img.itch.zone/aW1hZ2UvMTY0Nzg2NS85Njk1MTAzLnBuZw==/original/TbgdA9.png" width="400px" /><a>


### PR DESCRIPTION
I've updated the Readme to include my theme, if I may please have it added to the list when you have a moment.

![Aseprite-theme-thumb](https://user-images.githubusercontent.com/55040983/182721971-952b73b0-06ee-4378-81be-83a9f9f846a5.png)

This Theme is a Dark Blue / Pixel Art Theme.

You can visit and see the details on my itch page: 
https://theretrodragon.itch.io/aseprite-darkblue-theme

