### PR TITLE
Added Frigus Nox theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,8 @@ This is an incomplete list of themes created by Aseprite users (pull requests ar
 
 <a href="https://github.com/catppuccin/aseprite">Catppuccin for Aseprite <br>
 <img src="https://raw.githubusercontent.com/catppuccin/aseprite/ad08aa0cb6addb68461b275188d4e31cad518855/assets/preview.webp" width="400px" /><a>
+
+----
+
+<a href="https://github.com/Furash/frigus_nox_aseprite">Frigus Nox<br>
+<img src="https://raw.githubusercontent.com/Furash/frigus_nox_aseprite/main/screenshots/theme-preview.png" width="400px" /></a>


### PR DESCRIPTION
Adds Frigus Nox theme. Forked from default-dark, palette-remapped.

Repo: https://github.com/Furash/frigus_nox_aseprite